### PR TITLE
Update Arrow Navigation ver to 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ The `FocusableGroup` component will receive all HTML attributes and events for t
 | id | string | - | The group id. Must be unique |
 | as | string | div | The HTML tag to be used as wrapper |
 | options | object | - | The options for the group. |
-| options.onFocus | function | - | Callback function to be called when the group receives focus |
-| options.onBlur | function | - | Callback function to be called when the group loses focus |
+| options.onFocus | function | - | Callback function to be called when the group receives focus. It returns a object with focus result that includes prev, current and direction |
+| options.onBlur | function | - | Callback function to be called when the group loses focus. It returns a object with focus result that includes next, current and direction |
 | options.firstElement | string | - | The id of the first element to receive focus when the group receives focus |
 | options.nextGroupByDirection | string | - | The direction to navigate when the last element of the group receives focus. Possible values are: 'up', 'down', 'left' and 'right' |
 | options.saveLast | boolean | false | If true, the last focused element will be saved in firstElement |
@@ -91,8 +91,8 @@ The `FocusableElement` component will receive all HTML attributes and events for
 | id | string | - | The element id. Must be unique |
 | as | string | div | The HTML tag to be used as wrapper |
 | options | object | - | The options for the element. |
-| options.onFocus | function | - | Callback function to be called when the element receives focus |
-| options.onBlur | function | - | Callback function to be called when the element loses focus |
+| options.onFocus | function | - | Callback function to be called when the element receives focus. It returns a object with focus result that includes prev, current and direction |
+| options.onBlur | function | - | Callback function to be called when the element loses focus. It returns a object with focus result that includes next, current and direction |
 | options.nextElementByDirection | string | - | The direction to navigate when the element receives focus. Possible values are: 'up', 'down', 'left' and 'right' |
 
 ## Listeners

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "Boris Belmar <borisbelmarm@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@arrow-navigation/core": "1.2.3"
+    "@arrow-navigation/core": "1.2.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17 || ^18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrow-navigation/react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A light and performant React implementation for @arrow-navigation/core package.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@babel/preset-env": "7.21.4",
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.21.4",
-    "@hookform/resolvers": "3.0.1",
     "@storybook/addon-essentials": "7.0.2",
     "@storybook/addon-interactions": "7.0.2",
     "@storybook/addon-links": "7.0.2",

--- a/src/hooks/listeners/useListenLastElementReached.ts
+++ b/src/hooks/listeners/useListenLastElementReached.ts
@@ -17,7 +17,8 @@ export default function useListenLastElementReached(
   const api = getArrowNavigation()
 
   useEffect(() => {
-    const handler = (focusedElement: FocusableElement) => {
+    const handler = (focusedElement: FocusableElement, dir: Direction) => {
+      if (!dir) return
       if (group?.toString() && focusedElement.group !== group) return
       if (!elementPattern || focusedElement.el.id.match(elementPattern)) {
         const noNextElement = api.getNextElement({ direction, inGroup }) === null

--- a/src/hooks/listeners/useListenLastGroupReached.ts
+++ b/src/hooks/listeners/useListenLastGroupReached.ts
@@ -16,7 +16,8 @@ export default function useListenLastGroupReached(
   const api = getArrowNavigation()
 
   useEffect(() => {
-    const handler = (groupFocused: FocusableGroup) => {
+    const handler = (groupFocused: FocusableGroup, dir: Direction) => {
+      if (!dir) return
       if (group?.toString() && groupFocused.el.id !== group) return
       if (!groupPattern || groupFocused.el.id.match(groupPattern)) {
         const noNextGroup = api.getNextGroup({ direction }) === null

--- a/src/hooks/watchers/useWatchNextGroup.ts
+++ b/src/hooks/watchers/useWatchNextGroup.ts
@@ -12,6 +12,7 @@ export default function useWatchNextGroup({ direction }: Props = {}) {
   useEffect(() => {
     const api = getArrowNavigation()
     const handler = (_group: FocusableGroup, pressedDir: Direction) => {
+      if (!pressedDir) return
       if (!direction || direction === pressedDir) {
         setNextGroup(api.getNextGroup({ direction: direction || pressedDir }) || null)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@arrow-navigation/core@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@arrow-navigation/core/-/core-1.2.3.tgz#b1b50efa87f8ab4d113cb19746f42c693a08c7c7"
-  integrity sha512-wQSaTJIKvmVsjRnHtcLXlz6VSEthTdlJnDxdVAKltzkOMdYvrbCLjZCEdRF7Zx7gxKQfUpr5IEmWLLQO0ElCTA==
+"@arrow-navigation/core@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@arrow-navigation/core/-/core-1.2.4.tgz#d4abb638105ff33eb19ef2fc18f18e90e02e789b"
+  integrity sha512-PXMRwGitXBadVRrnCZuxqB4d/hJkDOHhixfs/VBlmqrBsZ1KRNzlb46c+qEELX5X9AKqRUuOyWLXg6+uZsnHCw==
 
 "@aw-web-design/x-default-browser@1.4.88":
   version "1.4.88"
@@ -1220,11 +1220,6 @@
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
   integrity sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==
-
-"@hookform/resolvers@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.0.1.tgz#e030f8ef5c407beb5be9bbafd68059cbdd02e0cb"
-  integrity sha512-n5oOt0cLw9mQNW3/k9zWaPsNWQcc0k6Jpc7XUrg2Q/AqqsHp3IVa1juqHCxczXI6uXHBa69ILc4pdtsRGyuzsw==
 
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.8"


### PR DESCRIPTION
## Update Element configurations

| Name | Type | Default | Description |
| --- | --- | --- | --- |
| options.onFocus | function | - | Callback function to be called when the element receives focus. It returns a object with focus result that includes prev, current and direction |
| options.onBlur | function | - | Callback function to be called when the element loses focus. It returns a object with focus result that includes next, current and direction |

## Update Group configurations

| Name | Type | Default | Description |
| --- | --- | --- | --- |
| options.onFocus | function | - | Callback function to be called when the group receives focus. It returns a object with focus result that includes prev, current and direction |
| options.onBlur | function | - | Callback function to be called when the group loses focus. It returns a object with focus result that includes next, current and direction |

## Update events on Arrow Navigation

Now, the first focus now throws the events.