### PR TITLE
Fix byOrder, improve docs and expose utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The `FocusableGroup` component will receive all HTML attributes and events for t
 | options.viewportSafe | boolean | true | If true, the navigation will be limited to the viewport |
 | options.threshold | number | 0 | The threshold to intersection discriminator |
 | options.keepFocus | boolean | false | If true, the focus will be kept in the group when the last element receives focus |
+| options.byOrder | ORDER | 'horizontal' | Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementIdByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options. |
+| options.cols | number - { number: number } | 1 | The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 } |
 
 ### `FocusableElement`
 
@@ -94,6 +96,7 @@ The `FocusableElement` component will receive all HTML attributes and events for
 | options.onFocus | function | - | Callback function to be called when the element receives focus. It returns a object with focus result that includes prev, current and direction |
 | options.onBlur | function | - | Callback function to be called when the element loses focus. It returns a object with focus result that includes next, current and direction |
 | options.nextElementByDirection | string | - | The direction to navigate when the element receives focus. Possible values are: 'up', 'down', 'left' and 'right' |
+| options.order | number | - | The order of the element. No default value. This is needed when the group is setted to navigate byOrder. If no setted, byOrder will be ignored. |
 
 ## Listeners
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "git+https://github.com/borisbelmar/arrow-navigation-react.git"
   },
   "dependencies": {
-    "@arrow-navigation/core": "1.2.10"
+    "@arrow-navigation/core": "1.2.11"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17 || ^18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrow-navigation/react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A light and performant React implementation for @arrow-navigation/core package.",
   "publishConfig": {
     "access": "public"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-export { initArrowNavigation, getArrowNavigation, ArrowNavigationEvents } from '@arrow-navigation/core'
+export {
+  initArrowNavigation,
+  getArrowNavigation,
+  ArrowNavigationEvents,
+  ArrowNavigationOrder,
+  getElementIdByOrder
+} from '@arrow-navigation/core'
+
 export type {
   FocusableElement as IFocusableElement,
   FocusableGroup as IFocusableGroup,
@@ -6,5 +13,6 @@ export type {
   FocusableGroupOptions,
   Direction
 } from '@arrow-navigation/core'
+
 export * from './components'
 export * from './hooks'

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@arrow-navigation/core@1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@arrow-navigation/core/-/core-1.2.10.tgz#31f46f1dc08f26329da267bf80349cc4f01175b3"
-  integrity sha512-nIM2zdgNt51o0Ai2F1pss0SllKwJu3TqP+VZ4+BzGoXn/yjx2b93YriohRSWooynFXxow4rLdgRJ6sCEnezEVQ==
+"@arrow-navigation/core@1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@arrow-navigation/core/-/core-1.2.11.tgz#3ab52fca26da810812de20a97bfcaf666692c90b"
+  integrity sha512-y//vTU/oSIACxZRvD3/F5VLZr4K3apk+krqunFy5SyZT69Po/DshK9GqIYN0FnJ90lvFBxTfVSBHPf991CBrKw==
 
 "@aw-web-design/x-default-browser@1.4.88":
   version "1.4.88"


### PR DESCRIPTION
- Fix grid bug with cols.
- Add byOrder features and configs to documentation.
- Expose `ArrowNavigationOrder` constants and `getElementIdByOrder` utility.

More info at https://github.com/borisbelmar/arrow-navigation/compare/v1.2.10...v1.2.11