### PR TITLE
Refactor and New Features / v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A light and performant React implementation for [@arrow-navigation/core]('https:
 ## Installation
 
 ```bash
-npm install @arrow-navigation/react
+npm install --save @arrow-navigation/react @arrow-navigation/core
 
 # or
 
-yarn add @arrow-navigation/react
+yarn add @arrow-navigation/react @arrow-navigation/core
 ```
 
 ## Usage
@@ -68,17 +68,16 @@ The `FocusableGroup` component will receive all HTML attributes and events for t
 | --- | --- | --- | --- |
 | id | string | - | The group id. Must be unique |
 | as | string | div | The HTML tag to be used as wrapper |
-| options | object | - | The options for the group. |
-| options.onFocus | function | - | Callback function to be called when the group receives focus. It returns a object with focus result that includes prev, current and direction |
-| options.onBlur | function | - | Callback function to be called when the group loses focus. It returns a object with focus result that includes next, current and direction |
-| options.firstElement | string | - | The id of the first element to receive focus when the group receives focus |
-| options.nextGroupByDirection | string | - | The direction to navigate when the last element of the group receives focus. Possible values are: 'up', 'down', 'left' and 'right' |
-| options.saveLast | boolean | false | If true, the last focused element will be saved and used as firstElement |
-| options.viewportSafe | boolean | true | If true, the navigation will be limited to the viewport |
-| options.threshold | number | 0 | The threshold to intersection discriminator |
-| options.keepFocus | boolean | false | If true, the focus will be kept in the group when the last element receives focus |
-| options.byOrder | ORDER | 'horizontal' | Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementIdByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options. |
-| options.cols | number - { number: number } | 1 | The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 } |
+| onFocus | function | - | Callback function to be called when the group receives focus. It returns a object with focus result that includes prev, current and direction |
+| onBlur | function | - | Callback function to be called when the group loses focus. It returns a object with focus result that includes next, current and direction |
+| firstElement | string | - | The id of the first element to receive focus when the group receives focus |
+| nextUp / nextDown / nextRight / nextLeft | string | - | The next group id by direction. |
+| saveLast | boolean | false | If true, the last focused element will be saved and used as firstElement |
+| viewportSafe | boolean | true | If true, the navigation will be limited to the viewport |
+| threshold | number | 0 | The threshold to intersection discriminator |
+| keepFocus | boolean | false | If true, the focus will be kept in the group when the last element receives focus |
+| byOrder | ORDER | 'horizontal' | Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementIdByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options. |
+| cols | number - { number: number } | 1 | The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 } |
 
 ### `FocusableElement`
 
@@ -92,11 +91,44 @@ The `FocusableElement` component will receive all HTML attributes and events for
 | --- | --- | --- | --- |
 | id | string | - | The element id. Must be unique |
 | as | string | div | The HTML tag to be used as wrapper |
-| options | object | - | The options for the element. |
-| options.onFocus | function | - | Callback function to be called when the element receives focus. It returns a object with focus result that includes prev, current and direction |
-| options.onBlur | function | - | Callback function to be called when the element loses focus. It returns a object with focus result that includes next, current and direction |
-| options.nextElementByDirection | string | - | The direction to navigate when the element receives focus. Possible values are: 'up', 'down', 'left' and 'right' |
-| options.order | number | - | The order of the element. No default value. This is needed when the group is setted to navigate byOrder. If no setted, byOrder will be ignored. |
+| onFocus | function | - | Callback function to be called when the element receives focus. It returns a object with focus result that includes prev, current and direction |
+| onBlur | function | - | Callback function to be called when the element loses focus. It returns a object with focus result that includes next, current and direction |
+| nextUp / nextDown / nextRight / nextLeft | string | NextFocusable |  The next element or group by direction. In the case of group, must be an object { kind: 'group', id: 'group-0 } |
+| order | number | - | The order of the element. No default value. This is needed when the group is setted to navigate byOrder. If no setted, byOrder will be ignored. |
+
+
+### `useFocusableElement`
+
+Hook to make an element focusable. The element must be a child of a `FocusableGroup` component and the HTML tag used as wrapper must be focusable, for example, `input`, `button`, `a`, `select`, `textarea`, etc. The hook props are the same as `FocusableElement` component.
+
+#### Usage
+
+```jsx
+import { useFocusableElement } from '@arrow-navigation/react'
+
+const MyButton = ({ id }) => {
+  // Is important to pass the id to the hook and to the button
+  useFocusableElement({ id })
+
+  return (
+    <button id={id}>
+      Button 1
+    </button>
+  )
+}
+
+const App = () => {
+  return (
+    <div>
+      <FocusableGroup id="group-1">
+        <MyButton id="btn-1" />
+        <MyButton id="btn-2" />
+        <MyButton id="btn-3" />
+      </FocusableGroup>
+    </div>
+  )
+}
+```
 
 ## Listeners
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrow-navigation/react",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "A light and performant React implementation for @arrow-navigation/core package.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -40,13 +40,12 @@
     "type": "git",
     "url": "git+https://github.com/borisbelmar/arrow-navigation-react.git"
   },
-  "dependencies": {
-    "@arrow-navigation/core": "1.2.11"
-  },
   "peerDependencies": {
+    "@arrow-navigation/core": "^2.0.0",
     "react": "^16.8.0 || ^17 || ^18"
   },
   "devDependencies": {
+    "@arrow-navigation/core": "2.0.0",
     "@babel/preset-env": "7.21.4",
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.21.4",

--- a/src/components/FocusableElement.tsx
+++ b/src/components/FocusableElement.tsx
@@ -1,25 +1,50 @@
-import { createElement, useRef } from 'react'
-import type { FocusableElementOptions } from '@arrow-navigation/core'
+import { createElement } from 'react'
+import type { FocusableByDirection, FocusableElementOptions } from '@arrow-navigation/core'
 import { useFocusableElement } from '..'
 
+export type Options = {
+  order?: FocusableElementOptions['order']
+  onFocus?: FocusableElementOptions['onFocus']
+  onBlur?: FocusableElementOptions['onBlur']
+  nextUp?: FocusableByDirection['up']
+  nextDown?: FocusableByDirection['down']
+  nextLeft?: FocusableByDirection['left']
+  nextRight?: FocusableByDirection['right']
+}
+
 type Props = {
+  id: string
   children: React.ReactNode
   as?: React.ElementType
-  options?: FocusableElementOptions
-} & React.HTMLAttributes<HTMLDivElement>
+} & Options & React.HTMLAttributes<HTMLDivElement>
 
 export default function FocusableElement({
   children,
+  id,
   as = 'button',
-  options,
+  onFocus,
+  onBlur,
+  order,
+  nextDown,
+  nextLeft,
+  nextRight,
+  nextUp,
   ...props
 }: Props) {
-  const ref = useRef(null)
-  useFocusableElement({ options, ref })
+  useFocusableElement({
+    id,
+    nextDown,
+    nextLeft,
+    nextRight,
+    nextUp,
+    onFocus,
+    onBlur,
+    order
+  })
 
   return createElement(
     as,
-    { ...props, ref },
+    { ...props, id },
     children
   )
 }

--- a/src/components/FocusableGroup/FocusableGroup.test.tsx
+++ b/src/components/FocusableGroup/FocusableGroup.test.tsx
@@ -47,12 +47,9 @@ describe('useFocusableGroup', () => {
   })
 
   it('should return the group context', () => {
-    jest.spyOn(React, 'useRef').mockReturnValueOnce({
-      current: {
-        id: 'test-group'
-      }
-    })
-
+    document.getElementById = jest.fn().mockReturnValueOnce(
+      document.createElement('div').id = 'test-group'
+    )
     const { result } = renderHook(() => useFocusableGroup(), {
       wrapper: ({ children }: { children: ReactNode }) => (
         <FocusableGroup id="test-group">
@@ -61,7 +58,6 @@ describe('useFocusableGroup', () => {
       )
     })
 
-    expect(result.current.groupId).toBe('test-group')
     expect(result.current.registerElement).toBeDefined()
     expect(result.current.unregisterElement).toBeDefined()
   })

--- a/src/components/FocusableGroup/FocusableGroup.tsx
+++ b/src/components/FocusableGroup/FocusableGroup.tsx
@@ -1,18 +1,34 @@
-import { createContext, createElement, ReactNode, useContext, useMemo, useRef } from 'react'
-import type { FocusableElementOptions, FocusableGroupOptions } from '@arrow-navigation/core'
+import { createContext, createElement, ReactNode, useContext, useMemo } from 'react'
+import type { FocusableElementOptions, FocusEventResult, FocusableGroupConfig, BlurEventResult } from '@arrow-navigation/core'
 import useFocusableGroupContext from './hooks/useFocusableGroupContext'
+
+export type GroupOptions = {
+  firstElement?: string,
+  byOrder?: 'horizontal' | 'vertical' | 'grid'
+  cols?: number | Record<number, number>
+  saveLast?: boolean
+  viewportSafe?: boolean
+  threshold?: number
+  onFocus?: (result: FocusEventResult<FocusableGroupConfig>) => void
+  onBlur?: (result: BlurEventResult<FocusableGroupConfig>) => void
+  keepFocus?: boolean
+  arrowDebounce?: boolean
+  nextUp?: string
+  nextDown?: string
+  nextLeft?: string
+  nextRight?: string
+}
 
 type Props = {
   id: string
   children: ReactNode
   as?: React.ElementType
-  options?: FocusableGroupOptions
-} & React.HTMLAttributes<HTMLDivElement>
+} & GroupOptions & React.HTMLAttributes<HTMLDivElement>
 
 type ContextValue = {
   groupId: string
-  registerElement: (element: HTMLElement, options?: FocusableElementOptions) => void
-  unregisterElement: (element: HTMLElement) => void
+  registerElement: (id: string, options?: FocusableElementOptions) => void
+  unregisterElement: (id: string) => void
 }
 
 const GroupContext = createContext<ContextValue | null>(null)
@@ -21,15 +37,42 @@ export function FocusableGroup({
   id,
   as = 'div',
   children,
-  options,
+  firstElement,
+  byOrder,
+  cols,
+  saveLast,
+  viewportSafe,
+  threshold,
+  onFocus,
+  onBlur,
+  keepFocus,
+  arrowDebounce,
+  nextUp,
+  nextDown,
+  nextLeft,
+  nextRight,
   ...props
 }: Props) {
-  const ref = useRef(null)
-
   const {
     registerElement,
     unregisterElement
-  } = useFocusableGroupContext({ groupRef: ref, options })
+  } = useFocusableGroupContext({
+    groupId: id,
+    firstElement,
+    nextUp,
+    nextDown,
+    nextLeft,
+    nextRight,
+    byOrder,
+    cols,
+    saveLast,
+    viewportSafe,
+    threshold,
+    onFocus,
+    onBlur,
+    keepFocus,
+    arrowDebounce
+  })
 
   const value = useMemo(() => ({
     groupId: id,
@@ -41,7 +84,6 @@ export function FocusableGroup({
     as,
     {
       ...props,
-      ref,
       id
     },
     (

--- a/src/components/FocusableGroup/hooks/useFocusableGroupContext.test.tsx
+++ b/src/components/FocusableGroup/hooks/useFocusableGroupContext.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-import { RefObject } from 'react'
 import { renderHook } from '@testing-library/react-hooks'
 import { getArrowNavigation, initArrowNavigation } from '@arrow-navigation/core'
 import useFocusableGroupContext from './useFocusableGroupContext'
@@ -10,46 +9,43 @@ describe('useFocusableGroupContext', () => {
 
   const TEST_GROUP_ID = 'test-group'
 
-  const ref = {
-    current: {
-      id: TEST_GROUP_ID
-    }
-  } as RefObject<HTMLElement>
-
   beforeEach(() => {
     initArrowNavigation({ debug: true })
   })
 
   it('should register a group', () => {
-    const { result } = renderHook(() => useFocusableGroupContext({ groupRef: ref }))
+    const group = document.createElement('div')
+    group.id = TEST_GROUP_ID
+    document.body.appendChild(group)
+    const { result } = renderHook(() => useFocusableGroupContext({ groupId: TEST_GROUP_ID }))
 
     const api = getArrowNavigation()
 
-    expect(result.current.groupId).toBe(TEST_GROUP_ID)
     expect(result.current.registerElement).toBeDefined()
     expect(result.current.unregisterElement).toBeDefined()
     expect(api.getGroupConfig(TEST_GROUP_ID)).toBeDefined()
   })
 
   it('should register and unregister an element from group', () => {
-    const { result } = renderHook(() => useFocusableGroupContext({ groupRef: ref }))
+    const { result } = renderHook(() => useFocusableGroupContext({ groupId: TEST_GROUP_ID }))
     const element = document.createElement('button')
     element.id = 'test-element'
-    result.current.registerElement(element)
+    document.body.appendChild(element)
+    result.current.registerElement(element.id)
 
     const api = getArrowNavigation()
 
     expect(api.getRegisteredElements().has(element.id)).toBeDefined()
     expect(api._getState()?.groups.get(TEST_GROUP_ID)?.elements.has(element.id)).toBeDefined()
 
-    result.current.unregisterElement(element)
+    result.current.unregisterElement(element.id)
 
     expect(api.getRegisteredElements().has(element.id)).toBeFalsy()
     expect(api._getState()?.groups.get(TEST_GROUP_ID)?.elements.has(element.id)).toBeFalsy()
   })
 
   it('should throw an error if used without a ref node without id', () => {
-    const { result } = renderHook(() => useFocusableGroupContext({ groupRef: { current: null } }))
+    const { result } = renderHook(() => useFocusableGroupContext({ groupId: '' }))
 
     expect(result.error).toBeDefined()
     expect(result.error?.message).toBe('groupRef must be a ref object with a current property containing a HTMLElement with an id')

--- a/src/hooks/listeners/useListenElementFocused.test.ts
+++ b/src/hooks/listeners/useListenElementFocused.test.ts
@@ -15,6 +15,7 @@ describe('useListenLastElementReached', () => {
     const id = 'test'
     const element = document.createElement('button')
     element.id = id
+    document.body.appendChild(element)
 
     const api = getArrowNavigation()
 
@@ -22,7 +23,9 @@ describe('useListenLastElementReached', () => {
 
     expect(result.current).toBeUndefined()
 
-    api.registerElement(element, 'test-group')
+    api.registerElement(id, 'test-group')
+
+    api.setFocusElement(id)
 
     expect(cb).toHaveBeenCalledTimes(1)
   })

--- a/src/hooks/listeners/useListenElementFocused.ts
+++ b/src/hooks/listeners/useListenElementFocused.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, FocusableElement } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, FocusEventResult, FocusableElement } from '@arrow-navigation/core'
 import { useEffect } from 'react'
 import useArrowNavigation from '../useArrowNavigation'
 
@@ -8,8 +8,8 @@ export default function useListenElementFocused(cb: Callback, id: string) {
   const api = useArrowNavigation()
 
   useEffect(() => {
-    const onFocus = (element: FocusableElement) => {
-      if (element?.el?.id === id) {
+    const onFocus = ({ current }: FocusEventResult<FocusableElement>) => {
+      if (current?.id === id) {
         cb()
       }
     }

--- a/src/hooks/listeners/useListenLastElementReached.test.ts
+++ b/src/hooks/listeners/useListenLastElementReached.test.ts
@@ -21,11 +21,14 @@ describe('useListenLastElementReached', () => {
 
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group', { nextElementByDirection: { right: 'test-2' } })
+    document.body.appendChild(element1)
+    api.registerElement(element1.id, 'test-group', { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group', { nextElementByDirection: { left: 'test-1' } })
+    document.body.appendChild(element2)
+    api.registerElement(element2.id, 'test-group', { nextByDirection: { left: 'test-1' } })
 
     api._forceNavigate('ArrowRight')
 

--- a/src/hooks/listeners/useListenLastElementReached.ts
+++ b/src/hooks/listeners/useListenLastElementReached.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, Direction, FocusableElement, getArrowNavigation } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, Direction, FocusEventResult, FocusableElement, getArrowNavigation } from '@arrow-navigation/core'
 import { useEffect } from 'react'
 
 export type LastElementCallback = (element: string | null) => void
@@ -17,13 +17,16 @@ export default function useListenLastElementReached(
   const api = getArrowNavigation()
 
   useEffect(() => {
-    const handler = (focusedElement: FocusableElement, dir: Direction) => {
+    const handler = ({
+      current: focusedElement,
+      direction: dir
+    }: FocusEventResult<FocusableElement>) => {
       if (!dir) return
-      if (group?.toString() && focusedElement.group !== group) return
-      if (!elementPattern || focusedElement.id.match(elementPattern)) {
+      if (group?.toString() && focusedElement?.group !== group) return
+      if (!elementPattern || focusedElement?.id.match(elementPattern)) {
         const noNextElement = api.getNextElement({ direction, inGroup }) === null
         if (noNextElement) {
-          cb(focusedElement.id)
+          cb(focusedElement?.id || null)
         }
       }
     }

--- a/src/hooks/listeners/useListenLastGroupReached.test.ts
+++ b/src/hooks/listeners/useListenLastGroupReached.test.ts
@@ -21,19 +21,24 @@ describe('useListenLastGroupReached', () => {
 
     const group1 = document.createElement('div')
     group1.id = 'test-group-1'
-    api.registerGroup(group1, { nextGroupByDirection: { right: 'test-group-2' } })
+    document.body.appendChild(group1)
+    api.registerGroup(group1.id, { nextGroupByDirection: { right: 'test-group-2' } })
 
     const group2 = document.createElement('div')
     group2.id = 'test-group-2'
-    api.registerGroup(group2, { nextGroupByDirection: { left: 'test-group-1' } })
+    document.body.appendChild(group2)
+    api.registerGroup(group2.id, { nextGroupByDirection: { left: 'test-group-1' } })
 
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group-1', { nextElementByDirection: { right: 'test-2' } })
+    group1.appendChild(element1)
+    api.registerElement(element1.id, 'test-group-1', { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group-2', { nextElementByDirection: { left: 'test-1' } })
+    group2.appendChild(element2)
+    api.registerElement(element2.id, 'test-group-2', { nextByDirection: { left: 'test-1' } })
 
     expect(cb).toHaveBeenCalledTimes(0)
 

--- a/src/hooks/listeners/useListenLastGroupReached.ts
+++ b/src/hooks/listeners/useListenLastGroupReached.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, Direction, FocusableGroup, getArrowNavigation } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, Direction, FocusEventResult, FocusableGroup, getArrowNavigation } from '@arrow-navigation/core'
 import { useEffect } from 'react'
 
 export type LastGroupCallback = (group: string | null) => void
@@ -16,13 +16,16 @@ export default function useListenLastGroupReached(
   const api = getArrowNavigation()
 
   useEffect(() => {
-    const handler = (groupFocused: FocusableGroup, dir: Direction) => {
+    const handler = ({
+      current: groupFocused,
+      direction: dir
+    }: FocusEventResult<FocusableGroup>) => {
       if (!dir) return
-      if (group?.toString() && groupFocused.id !== group) return
-      if (!groupPattern || groupFocused.id.match(groupPattern)) {
+      if (group?.toString() && groupFocused?.id !== group) return
+      if (!groupPattern || groupFocused?.id.match(groupPattern)) {
         const noNextGroup = api.getNextGroup({ direction }) === null
         if (noNextGroup) {
-          cb(groupFocused.el?.id)
+          cb(groupFocused?.id || null)
         }
       }
     }

--- a/src/hooks/useFocusableElement.test.tsx
+++ b/src/hooks/useFocusableElement.test.tsx
@@ -1,6 +1,6 @@
 import { initArrowNavigation } from '@arrow-navigation/core'
 import { renderHook } from '@testing-library/react-hooks'
-import React, { RefObject } from 'react'
+import React from 'react'
 import { FocusableGroup } from '..'
 import useFocusableElement from './useFocusableElement'
 
@@ -13,35 +13,23 @@ describe('useFocusableElement', () => {
   })
 
   it('should throw an error if used without a FocusableGroup', () => {
-    const mockRef = {
-      current: {
-        id: 'test-element'
-      }
-    } as RefObject<HTMLButtonElement>
-    const { result } = renderHook(() => useFocusableElement({ ref: mockRef }))
+    const id = 'test-group'
+    const group = document.createElement('div')
+    group.id = id
+    document.body.appendChild(group)
+    const { result } = renderHook(() => useFocusableElement({ id }))
 
     expect(result.error).toBeDefined()
     expect(result.error?.message).toBe('useFocusableGroup must be used within a FocusableGroup')
   })
 
   it('should register and unregister an element based on mount and dismount', () => {
-    jest.spyOn(React, 'useRef').mockReturnValueOnce({
-      current: {
-        id: 'test-group'
-      }
-    })
+    const id = 'test-element'
+    const element = document.createElement('button')
+    element.id = id
+    document.body.appendChild(element)
 
-    const mockRef = {
-      current: {
-        id: 'test-element',
-        matches: () => true,
-        getAttribute: () => null,
-        setAttribute: jest.fn(),
-        focus: jest.fn()
-      }
-    } as unknown as RefObject<HTMLButtonElement>
-
-    const { result } = renderHook(() => useFocusableElement({ ref: mockRef }), {
+    const { result } = renderHook(() => useFocusableElement({ id }), {
       wrapper: ({ children }: { children: React.ReactNode }) => (
         <FocusableGroup id="test-group">
           {children}

--- a/src/hooks/useFocusableElement.ts
+++ b/src/hooks/useFocusableElement.ts
@@ -1,25 +1,49 @@
-import { RefObject, useEffect } from 'react'
-import type { FocusableElementOptions } from '@arrow-navigation/core'
+import { useEffect, useMemo } from 'react'
 import { useFocusableGroup } from '@/components/FocusableGroup/FocusableGroup'
+import { Options } from '@/components/FocusableElement'
+import { FocusableElementOptions } from '@arrow-navigation/core'
 
 type Props = {
-  ref: RefObject<HTMLElement>
-  options?: FocusableElementOptions
-}
+  id: string
+} & Options
 
-export default function useFocusableElement({ ref, options }: Props) {
+export default function useFocusableElement({
+  id,
+  nextDown,
+  nextLeft,
+  nextRight,
+  nextUp,
+  order,
+  onBlur,
+  onFocus
+}: Props) {
   const { registerElement, unregisterElement } = useFocusableGroup()
 
+  const options: FocusableElementOptions = useMemo(() => ({
+    nextByDirection: {
+      down: nextDown,
+      left: nextLeft,
+      right: nextRight,
+      up: nextUp
+    },
+    order,
+    onBlur,
+    onFocus
+  }), [
+    nextDown,
+    nextLeft,
+    nextRight,
+    nextUp,
+    order,
+    onBlur,
+    onFocus
+  ])
+
   useEffect(() => {
-    const element = ref?.current
-    if (element) {
-      registerElement(element, options)
-    }
+    registerElement(id, options)
 
     return () => {
-      if (element) {
-        unregisterElement(element)
-      }
+      unregisterElement(id)
     }
-  }, [options, registerElement, unregisterElement, ref])
+  }, [options, registerElement, unregisterElement, id])
 }

--- a/src/hooks/watchers/useWatchElementFocused.test.ts
+++ b/src/hooks/watchers/useWatchElementFocused.test.ts
@@ -15,11 +15,14 @@ describe('useWatchElementFocused', () => {
     const api = getArrowNavigation()
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group', { nextElementByDirection: { right: 'test-2' } })
+    document.body.appendChild(element1)
+    api.registerElement(element1.id, 'test-group', { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group', { nextElementByDirection: { left: 'test-1' } })
+    document.body.appendChild(element2)
+    api.registerElement(element2.id, 'test-group', { nextByDirection: { left: 'test-1' } })
 
     const { result } = renderHook(() => useWatchElementFocused('test-1'))
 

--- a/src/hooks/watchers/useWatchElementFocused.ts
+++ b/src/hooks/watchers/useWatchElementFocused.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, FocusableElement } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, FocusEventResult, FocusableElement } from '@arrow-navigation/core'
 import { useEffect, useState } from 'react'
 import useArrowNavigation from '../useArrowNavigation'
 
@@ -7,8 +7,8 @@ export default function useWatchElementFocused(id: string) {
   const [focused, setFocused] = useState(api.getFocusedElement()?.id === id)
 
   useEffect(() => {
-    const onFocus = (element: FocusableElement) => {
-      setFocused(element?.el?.id === id)
+    const onFocus = ({ current }: FocusEventResult<FocusableElement>) => {
+      setFocused(current?.id === id)
     }
 
     api.on(ArrowNavigationEvents.CURRENT_ELEMENT_CHANGE, onFocus)

--- a/src/hooks/watchers/useWatchLastElement.test.ts
+++ b/src/hooks/watchers/useWatchLastElement.test.ts
@@ -21,11 +21,14 @@ describe('useWatchLastElement', () => {
 
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group', { nextElementByDirection: { right: 'test-2' } })
+    document.body.appendChild(element1)
+    api.registerElement(element1.id, 'test-group', { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group', { nextElementByDirection: { left: 'test-1' } })
+    document.body.appendChild(element2)
+    api.registerElement(element2.id, 'test-group', { nextByDirection: { left: 'test-1' } })
 
     api._forceNavigate('ArrowRight')
 

--- a/src/hooks/watchers/useWatchLastGroup.test.ts
+++ b/src/hooks/watchers/useWatchLastGroup.test.ts
@@ -21,19 +21,24 @@ describe('useWatchLastGroup', () => {
 
     const group1 = document.createElement('div')
     group1.id = 'test-group-1'
-    api.registerGroup(group1, { nextGroupByDirection: { right: 'test-group-2' } })
+    document.body.appendChild(group1)
+    api.registerGroup(group1.id, { nextGroupByDirection: { right: 'test-group-2' } })
 
     const group2 = document.createElement('div')
     group2.id = 'test-group-2'
-    api.registerGroup(group2, { nextGroupByDirection: { left: 'test-group-1' } })
+    document.body.appendChild(group2)
+    api.registerGroup(group2.id, { nextGroupByDirection: { left: 'test-group-1' } })
 
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group-1', { nextElementByDirection: { right: 'test-2' } })
+    group1.appendChild(element1)
+    api.registerElement(element1.id, group1.id, { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group-2', { nextElementByDirection: { left: 'test-1' } })
+    group2.appendChild(element2)
+    api.registerElement(element2.id, 'test-group-2', { nextByDirection: { left: 'test-1' } })
 
     expect(result.current.reachedLastGroup).toBe(false)
 

--- a/src/hooks/watchers/useWatchLastGroup.ts
+++ b/src/hooks/watchers/useWatchLastGroup.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, Direction, FocusableGroup, getArrowNavigation } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, Direction, FocusEventResult, FocusableElement, getArrowNavigation } from '@arrow-navigation/core'
 import { useEffect, useMemo, useState } from 'react'
 
 interface Options {
@@ -15,17 +15,20 @@ export default function useWatchLastGroup(
   const [watchGroup, setWatchGroup] = useState<string | null>(group ?? null)
 
   useEffect(() => {
-    const handler = (groupFocused: FocusableGroup, dir: Direction) => {
+    const handler = ({
+      current: groupFocused,
+      direction: dir
+    }: FocusEventResult<FocusableElement>) => {
       if (!dir) return
-      if (group?.toString() && groupFocused.id !== group) return
-      if (groupPattern && !groupFocused.id.match(groupPattern)) {
+      if (group?.toString() && groupFocused?.id !== group) return
+      if (groupPattern && !groupFocused?.id.match(groupPattern)) {
         setReachedLastGroup(false)
         return
       }
       const noNextGroup = api.getNextGroup({ direction }) === null
       setReachedLastGroup(noNextGroup)
       if (noNextGroup) {
-        setWatchGroup(groupFocused.el?.id)
+        setWatchGroup(groupFocused?.id || null)
       }
     }
 

--- a/src/hooks/watchers/useWatchNextElement.test.ts
+++ b/src/hooks/watchers/useWatchNextElement.test.ts
@@ -21,15 +21,19 @@ describe('useWatchNextElement', () => {
 
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group', { nextElementByDirection: { right: 'test-2' } })
+    document.body.appendChild(element1)
+    api.registerElement(element1.id, 'test-group', { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group', { nextElementByDirection: { left: 'test-1', right: 'test-3' } })
+    document.body.appendChild(element2)
+    api.registerElement(element2.id, 'test-group', { nextByDirection: { left: 'test-1', right: 'test-3' } })
 
     const element3 = document.createElement('button')
     element3.id = 'test-3'
-    api.registerElement(element3, 'test-group', { nextElementByDirection: { left: 'test-2' } })
+    document.body.appendChild(element3)
+    api.registerElement(element3.id, 'test-group', { nextByDirection: { left: 'test-2' } })
 
     api._forceNavigate('ArrowRight')
 

--- a/src/hooks/watchers/useWatchNextElement.ts
+++ b/src/hooks/watchers/useWatchNextElement.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, Direction, FocusableElement, getArrowNavigation } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, Direction, FocusEventResult, FocusableElement, getArrowNavigation } from '@arrow-navigation/core'
 import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
@@ -14,13 +14,19 @@ export default function useWatchNextElement({ direction, group, inGroup }: Props
   useEffect(() => {
     const api = getArrowNavigation()
 
-    const handler = (el: FocusableElement, pressedDir: Direction) => {
-      if (group?.toString() && el.group !== group) return
+    const handler = ({
+      current: el,
+      direction: pressedDir
+    }: FocusEventResult<FocusableElement>) => {
+      if (group?.toString() && el?.group !== group) return
       if (!direction || direction === pressedDir) {
-        setNextElement(api.getNextElement({ direction: direction || pressedDir, inGroup }))
+        setNextElement(api.getNextElement({
+          direction: direction || pressedDir as Direction,
+          inGroup
+        }))
       }
       if (!direction) {
-        setDir(pressedDir)
+        setDir(pressedDir as Direction)
       }
     }
 

--- a/src/hooks/watchers/useWatchNextGroup.test.ts
+++ b/src/hooks/watchers/useWatchNextGroup.test.ts
@@ -21,27 +21,34 @@ describe('useWatchNextGroup', () => {
 
     const group1 = document.createElement('div')
     group1.id = 'test-group-1'
-    api.registerGroup(group1, { nextGroupByDirection: { right: 'test-group-2' } })
+    document.body.appendChild(group1)
+    api.registerGroup(group1.id, { nextGroupByDirection: { right: 'test-group-2' } })
 
     const group2 = document.createElement('div')
     group2.id = 'test-group-2'
-    api.registerGroup(group2, { nextGroupByDirection: { left: 'test-group-1', right: 'test-group-3' } })
+    document.body.appendChild(group2)
+    api.registerGroup(group2.id, { nextGroupByDirection: { left: 'test-group-1', right: 'test-group-3' } })
 
     const group3 = document.createElement('div')
     group3.id = 'test-group-3'
-    api.registerGroup(group3, { nextGroupByDirection: { left: 'test-group-2' } })
+    document.body.appendChild(group3)
+    api.registerGroup(group3.id, { nextGroupByDirection: { left: 'test-group-2' } })
 
     const element1 = document.createElement('button')
     element1.id = 'test-1'
-    api.registerElement(element1, 'test-group-1', { nextElementByDirection: { right: 'test-2' } })
+    group1.appendChild(element1)
+    api.registerElement(element1.id, group1.id, { nextByDirection: { right: 'test-2' } })
+    api.setFocusElement(element1.id)
 
     const element2 = document.createElement('button')
     element2.id = 'test-2'
-    api.registerElement(element2, 'test-group-2', { nextElementByDirection: { left: 'test-1', right: 'test-3' } })
+    group2.appendChild(element2)
+    api.registerElement(element2.id, group2.id, { nextByDirection: { left: 'test-1', right: 'test-3' } })
 
     const element3 = document.createElement('button')
     element3.id = 'test-3'
-    api.registerElement(element3, 'test-group-3', { nextElementByDirection: { left: 'test-2' } })
+    group3.appendChild(element3)
+    api.registerElement(element3.id, group3.id, { nextByDirection: { left: 'test-2' } })
 
     expect(result.current.nextGroup).toBeNull()
 

--- a/src/hooks/watchers/useWatchNextGroup.ts
+++ b/src/hooks/watchers/useWatchNextGroup.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationEvents, Direction, FocusableGroup, getArrowNavigation } from '@arrow-navigation/core'
+import { ArrowNavigationEvents, Direction, FocusEventResult, FocusableGroup, getArrowNavigation } from '@arrow-navigation/core'
 import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
@@ -11,7 +11,7 @@ export default function useWatchNextGroup({ direction }: Props = {}) {
 
   useEffect(() => {
     const api = getArrowNavigation()
-    const handler = (_group: FocusableGroup, pressedDir: Direction) => {
+    const handler = ({ direction: pressedDir }: FocusEventResult<FocusableGroup>) => {
       if (!pressedDir) return
       if (!direction || direction === pressedDir) {
         setNextGroup(api.getNextGroup({ direction: direction || pressedDir }) || null)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ export type {
   FocusableGroup as IFocusableGroup,
   FocusableElementOptions,
   FocusableGroupOptions,
-  Direction
+  Direction,
+  FocusEventResult,
+  BlurEventResult
 } from '@arrow-navigation/core'
 
 export * from './components'

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@arrow-navigation/core@1.2.11":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@arrow-navigation/core/-/core-1.2.11.tgz#3ab52fca26da810812de20a97bfcaf666692c90b"
-  integrity sha512-y//vTU/oSIACxZRvD3/F5VLZr4K3apk+krqunFy5SyZT69Po/DshK9GqIYN0FnJ90lvFBxTfVSBHPf991CBrKw==
+"@arrow-navigation/core@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@arrow-navigation/core/-/core-2.0.0.tgz#6eb86d1b71b60e93877fd76fc195b34cc71d4fca"
+  integrity sha512-TinEHRHGlS7r26/Lx7B+Oj4uc3d5oxyMHIJsPEVo/f5nt2Qgca5N7BJ1PJr2YTQgllQUVSI0cG/bdVy89awNSA==
 
 "@aw-web-design/x-default-browser@1.4.88":
   version "1.4.88"


### PR DESCRIPTION
# v2.0.0

## Breaking Changes
- The `FocusableElement`, `FocusableGroup`, and `useFocusableElement` no longer receive options as an object. Instead, they receive all options as separate props.
- The `@arrow-navigation/core` package is no longer included with this package and has become a peer dependency. It needs to be installed separately in your project (`^2.0.0`).

## Bugfixes
- An improvement has been added to handle focus loss. This ensures that the focus remains within the view without any risks.
- Made improvements to the `byOrder` functionality.
- The `resetGroupState` function has been added to the group dismount process. This fixes the issue where the `lastElement` was being set on a dismounted group config.
- A cooldown period has been added for registered elements to focus. This ensures that the next `initialFocusElement` or the `currentElement` is registered when focused.
